### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/main.rs
+++ b/main.rs
@@ -214,7 +214,7 @@ let mut a: f32 = 1.0;
           }
     }
     
-    println!("{:.?}",a);
+    println!("{:?}",a);
     }
     let mut y = 1.0;
     for i in 0 .. row_index{


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.